### PR TITLE
Export more GCFreeZone calls

### DIFF
--- a/include/hx/GC.h
+++ b/include/hx/GC.h
@@ -36,6 +36,9 @@ HXCPP_EXTERN_CLASS_ATTRIBUTES int   __hxcpp_gc_used_bytes();
 HXCPP_EXTERN_CLASS_ATTRIBUTES double __hxcpp_gc_mem_info(int inWhat);
 HXCPP_EXTERN_CLASS_ATTRIBUTES void  __hxcpp_enter_gc_free_zone();
 HXCPP_EXTERN_CLASS_ATTRIBUTES void  __hxcpp_exit_gc_free_zone();
+HXCPP_EXTERN_CLASS_ATTRIBUTES bool  __hxcpp_try_gc_free_zone();
+HXCPP_EXTERN_CLASS_ATTRIBUTES bool  __hxcpp_try_exit_gc_free_zone();
+HXCPP_EXTERN_CLASS_ATTRIBUTES bool  __hxcpp_in_gc_free_zone();
 HXCPP_EXTERN_CLASS_ATTRIBUTES void  __hxcpp_gc_safe_point();
 HXCPP_EXTERN_CLASS_ATTRIBUTES void  __hxcpp_spam_collects(int inEveryNCalls);
 HXCPP_EXTERN_CLASS_ATTRIBUTES void  __hxcpp_set_minimum_working_memory(int inBytes);
@@ -220,6 +223,8 @@ void ExitGCFreeZone();
 bool TryGCFreeZone();
 // retuns true if ExitGCFreeZone was called
 bool TryExitGCFreeZone();
+// returns true if we're in a GCFreeZone
+bool InGCFreeZone();
 
 class HXCPP_EXTERN_CLASS_ATTRIBUTES AutoGCFreeZone
 {

--- a/src/hx/gc/Immix.cpp
+++ b/src/hx/gc/Immix.cpp
@@ -5991,7 +5991,6 @@ public:
    }
 
 
-
    // Called by the collecting thread to make sure this allocator is paused.
    // The collecting thread has the lock, and will not be releasing it until
    //  it has finished the collect.
@@ -6381,6 +6380,16 @@ void ExitGCFreeZoneLocked()
    #ifndef HXCPP_SINGLE_THREADED_APP
       LocalAllocator *tla = GetLocalAlloc();
       tla->ExitGCFreeZoneLocked();
+   #endif
+}
+
+bool InGCFreeZone()
+{
+   #ifndef HXCPP_SINGLE_THREADED_APP
+      LocalAllocator *tla = GetLocalAlloc();
+      return tla->mGCFreeZone;
+   #else
+      return false;
    #endif
 }
 
@@ -6868,6 +6877,17 @@ void __hxcpp_exit_gc_free_zone()
    hx::ExitGCFreeZone();
 }
 
+
+bool __hxcpp_try_exit_gc_free_zone()
+{
+   return hx::TryExitGCFreeZone();
+}
+
+
+bool __hxcpp_in_gc_free_zone()
+{
+   return hx::InGCFreeZone();
+}
 
 void __hxcpp_gc_safe_point()
 {


### PR DESCRIPTION
Made the existing __hxcpp_try_gc_free_zone() function a public export.
Added a new __hxcpp_try_exit_gc_free_zone() function and publicly
exported it. Added a new hx:InGCFreeZone() boolean function. Added a
new __hxcpp_in_gc_free_zone() function and publicly exported it.